### PR TITLE
Deploy to Fly.io with PHP 7.4 compat fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitignore
+.dockerignore
+Dockerfile
+fly.toml
+CLAUDE.md
+*.md
+app/_cache/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Personal portfolio site for Black Ant Media, built on **Stacey CMS** (v2.3.0) — a flat-file PHP CMS with no database. All content and assets live in the filesystem.
+
+## Architecture
+
+### Request Flow
+`index.php` → loads all `app/**/*.inc.php` files → `Stacey` class routes the request → maps URL to a `content/` folder via `Helpers::url_to_file_path()` → renders matching template through `Cache` and `TemplateParser`.
+
+### Key Directories
+- **`content/`** — Page content as numbered directories (e.g., `2.work/13.git/`). The number prefix controls sort order and is stripped from URLs. Each folder contains a `.txt` file with key-value page data and associated asset files (images, etc.).
+- **`templates/`** — Stacey templates (`index.html`, `project.json`, etc.). Template name matches the `.txt` filename in the content folder (e.g., `project.txt` → `templates/project.json`).
+- **`app/`** — Core PHP framework: routing, caching, template parsing, asset types, markdown/JSON parsers.
+- **`public/`** — Static assets (CSS, JS, images). Served directly via `.htaccess` rewrite rules.
+- **`config/`** — `settings.php` (gitignored, see `settings.example.php` for structure). Contains Akismet key, SMTP config, contact form settings.
+
+### Template Language
+Stacey uses a custom template syntax parsed by `TemplateParser`:
+- `@variable` — Variable substitution from page data
+- `:partial_name` — Include a partial from `templates/partials/`
+- `foreach @collection do ... endforeach` — Loop with optional slice `[start:end]`
+- `if @var do ... endif` / `if ! @var do ... endif` — Conditionals
+- `get "route" do ... end` — Load data from another content path
+
+### Caching
+Pages are cached in `app/_cache/` (gitignored). Cache invalidation is based on file modification times across content and template files.
+
+## Development
+
+### CSS
+Sass compiles to CSS. Watch for changes:
+```
+sass --watch public/docs/css/sass:public/docs/css
+```
+(or run `./sass-watch`)
+
+### Running Locally
+Requires PHP 5+. Use any PHP-capable web server with mod_rewrite enabled. The `.htaccess` handles URL routing.
+
+### Deployment
+Capistrano deploys via git to the production server. `config/settings.php` is symlinked from shared storage on deploy.
+```
+cap deploy
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM php:7.4-apache
+
+RUN a2enmod rewrite
+
+RUN echo '<Directory /var/www/html>\n    AllowOverride All\n</Directory>' >> /etc/apache2/apache2.conf
+
+RUN echo "ServerName localhost:80" >> /etc/apache2/apache2.conf
+
+WORKDIR /var/www/html
+
+COPY --chown=www-data:www-data . .
+
+RUN mkdir -p app/_cache && chmod 777 app/_cache
+
+RUN echo '<?php' > config/settings.php
+
+CMD ["apache2-foreground"]

--- a/app/page-data.inc.php
+++ b/app/page-data.inc.php
@@ -110,7 +110,7 @@ Class PageData {
     $split_url = explode("/", $page->url_path);
     $page->slug = $split_url[count($split_url) - 1];
     # @page_name
-    $page->page_name = ucfirst(preg_replace('/[-_](.)/e', "' '.strtoupper('\\1')", $page->data['@slug']));
+    $page->page_name = ucfirst(preg_replace_callback('/[-_](.)/', function($m) { return ' '.strtoupper($m[1]); }, $page->data['@slug']));
     # @root_path
     $page->root_path = Helpers::relative_root_path();
     # @thumb
@@ -228,9 +228,9 @@ Class PageData {
       # set a variable with a name of 'key' on the page with a value of 'value'
       # if the template type is xml or html & the 'value' contains a newline character, parse it as markdown
       if(strpos($colon_split[1], "\n") !== false && preg_match('/xml|htm|html|rss|rdf|atom/', $split_path[1])) {
-        $page->$colon_split[0] = Markdown(trim($colon_split[1]));
+        $page->{$colon_split[0]} = Markdown(trim($colon_split[1]));
       } else {
-        $page->$colon_split[0] = trim($colon_split[1]);
+        $page->{$colon_split[0]} = trim($colon_split[1]);
       }
     }
   }

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,23 @@
+# fly.toml app configuration file generated for blackantmedia on 2026-02-17T15:10:02-05:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'blackantmedia'
+primary_region = 'ord'
+
+[build]
+
+[http_service]
+  internal_port = 80
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 1024

--- a/templates/index.html
+++ b/templates/index.html
@@ -234,7 +234,7 @@
 
     </div>
 
-    <script src="http://use.typekit.com/seh1ghz.js"></script>
+    <script src="https://use.typekit.com/seh1ghz.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/mootools/1.3.0/mootools-yui-compressed.js"></script>
     <script src="/min/index.php?g=js"></script>
     <script type="text/javascript">


### PR DESCRIPTION
## Summary
- Adds Dockerfile (`php:7.4-apache`) with mod_rewrite, AllowOverride All, writable cache dir, and dummy `config/settings.php`
- Adds `fly.toml` with correct `internal_port: 80` and `.dockerignore`
- Fixes three PHP 5→7 compatibility issues that broke the site:
  - `$page->$colon_split[0]` → `$page->{$colon_split[0]}` (indirect variable access change broke all `@variable` resolution in templates)
  - `preg_replace` `/e` modifier → `preg_replace_callback` (removed in PHP 7)
  - Typekit script `http://` → `https://` (mixed content blocked the fade-in effect and portfolio initialization)

## Test plan
- [x] `docker build && docker run -p 8080:80` — homepage and `/work/` return 200, no PHP warnings
- [x] Project JSON endpoints return resolved data (e.g. `"title":"Git"` not `"@title"`)
- [x] Content fades in on page load (Typekit callback fires)
- [x] Deployed and verified at https://blackantmedia.fly.dev/

🤖 Generated with [Claude Code](https://claude.com/claude-code)